### PR TITLE
Fix for file format change introduced in Bitwarden Desktop v2022.8.0

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -400,9 +400,16 @@ def decryptBitwardenJSON(options):
 
         # Get/Decrypt All Organization Keys
         for uuid in organizationKeys.items():
-            BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1]['key'], BitwardenSecrets['RSAPrivateKey'])
+            # File Format >= Desktop 2022.8.0
+            if type(uuid[1]) is dict:
+                BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1]['key'], BitwardenSecrets['RSAPrivateKey'])
+            # File Format < Desktop 2022.8.0
+            elif type(uuid[1]) is str:
+                BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1], BitwardenSecrets['RSAPrivateKey'])
+            else:
+                print(f"ERROR: Could Not Determine Organization Keys From File Format")
 
-        
+
         for a in datafile['data']:
 
             supportedGroups = ['folders', 'ciphers', 'collections', 'organizations']

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -399,13 +399,13 @@ def decryptBitwardenJSON(options):
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']
 
         # Get/Decrypt All Organization Keys
-        for uuid in organizationKeys.items():
+        for uuid, value in organizationKeys.items():
             # File Format >= Desktop 2022.8.0
-            if type(uuid[1]) is dict:
-                BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1]['key'], BitwardenSecrets['RSAPrivateKey'])
+            if type(value) is dict:
+                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value['key'], BitwardenSecrets['RSAPrivateKey'])
             # File Format < Desktop 2022.8.0
-            elif type(uuid[1]) is str:
-                BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1], BitwardenSecrets['RSAPrivateKey'])
+            elif type(value) is str:
+                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value, BitwardenSecrets['RSAPrivateKey'])
             else:
                 print(f"ERROR: Could Not Determine Organization Keys From File Format")
 

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -399,8 +399,8 @@ def decryptBitwardenJSON(options):
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']
 
         # Get/Decrypt All Organization Keys
-        for uuid in organizationKeys.items():
-            BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1]['key'], BitwardenSecrets['RSAPrivateKey'])
+        for uuid, key in organizationKeys.items():
+            BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(key, BitwardenSecrets['RSAPrivateKey'])
 
         
         for a in datafile['data']:

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -399,8 +399,8 @@ def decryptBitwardenJSON(options):
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']
 
         # Get/Decrypt All Organization Keys
-        for uuid, key in organizationKeys.items():
-            BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(key, BitwardenSecrets['RSAPrivateKey'])
+        for uuid in organizationKeys.items():
+            BitwardenSecrets['OrgSecrets'][uuid[0]] = decryptRSA(uuid[1]['key'], BitwardenSecrets['RSAPrivateKey'])
 
         
         for a in datafile['data']:


### PR DESCRIPTION
Fix for data.json file format change introduced in Bitwarden Desktop v2022.8.0. (https://github.com/GurpreetKang/BitwardenDecrypt/issues/17)

Encrypted Organization Key path changed from: /uuid/keys/organizationKeys/encrypted/uuid/
To: /uuid/keys/organizationKeys/encrypted/uuid/key/