### PR TITLE
Add Support For Decrypting Password Protected Encrypted JSON Export

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -317,7 +317,7 @@ def checkFileFormatVersion(options):
     
 
     # Check if datafile is a password protected excrypted json export.
-    if datafile.get("encrypted") is True and datafile.get("passwordProtected"):
+    if datafile.get("encrypted") and datafile.get("passwordProtected"):
         options.fileformat = "EncryptedJSON"
 
         # Email address is used as the salt in data.json, in password protected excrypted json exports there is an explicit salt key/value (and no email).
@@ -418,8 +418,7 @@ def decryptBitwardenJSON(options):
 
     
     elif (options.fileformat == "NEW"):
-    # data.json file format changed in v1.30+
-    #if (options.fileformat == "NEW"):
+        # data.json file format changed in v1.30+
 
         datafile = datafile[options.account['UUID']]
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ https://bitwarden.com/help/data-storage/#on-your-local-machine
 *Note: BitwardenDecrypt does not work with Bitwarden Encrypted JSON Exports.<br/>
 These exports lack the Protected Symmetric Key needed to decrypt entries.*
 
+*Password Protected Encrypted JSON Exports* are supported.
+Currently these can only be created using the [Bitwarden CLI](https://bitwarden.com/help/cli/#export).
+
+
 <br/>
 
 Outputs JSON containing:
@@ -61,8 +65,10 @@ https://paypal.me/GurpreetKang
 
 ## Limitations
 
+- Attachments are not supported (they are not stored locally in data.json)
 - Does not work with Bitwarden Encrypted JSON Exports.
 <br/>*These exports lack the Protected Symmetric Key needed to decrypt entries.*
+<br/>(Password Protected Encrypted JSON Exports are now supported)
 - ~~No validation of the CipherString.
 I.e. No verification of the MAC before decrypting.~~ Now verifies the MAC.
 - Can only decrypt EncryptionType: 2 (AesCbc256_HmacSha256_B64).  At the time of writing this is the default used for all entries in the personal vault.


### PR DESCRIPTION
Initial support for decrypting a password protected JSON export.

Closes #19