### PR TITLE
Fix stdout output

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -577,7 +577,11 @@ def decryptBitwardenJSON(options):
     if(decryptedEntries.get('sends')):
         decryptedEntries.move_to_end('sends')
 
-    return(json.dumps(decryptedEntries, indent=2, ensure_ascii=False))
+    return decryptedEntries
+
+
+def write_json(decryptedEntries, file):
+    json.dump(decryptedEntries, file, indent=2, ensure_ascii=False)
 
 
 def main(options):
@@ -588,17 +592,24 @@ def main(options):
         else:
             print(f"Saving Output To: {options.outputfile}\n")
     
-    decryptedJSON = decryptBitwardenJSON(options)
+    decryptedEntries = decryptBitwardenJSON(options)
+
+    encoding = options.encoding
+    # Force UTF-8 on Windows unless otherwise configured
+    if encoding is None and sys.platform == 'win32' and os.getenv('PYTHONIOENCODING') is None:
+        encoding = 'utf-8'
 
     if (options.outputfile):
         try:
-            with open(options.outputfile, "w", encoding="utf-8") as file:
-                file.write(decryptedJSON)
+            with open(options.outputfile, "w", encoding=encoding) as file:
+                write_json(decryptedEntries, file)
         except Exception as e:
             print(f"ERROR: Writing to {options.outputfile}")
 
     else:
-        print(decryptedJSON.encode("utf-8"))
+        if encoding is not None:
+            sys.stdout.reconfigure(encoding=encoding)
+        write_json(decryptedEntries, sys.stdout)
 
 
 if __name__ == "__main__":
@@ -606,6 +617,7 @@ if __name__ == "__main__":
     parser.add_argument("inputfile", nargs='?', default="data.json", help='INPUTFILE')
     parser.add_argument("--includesends", help="Include Sends in the output.", action="store_true", default=False)
     parser.add_argument("--output", metavar='OUTPUTFILE', action="store", dest='outputfile', help='Saves decrypted output to OUTPUTFILE')
+    parser.add_argument("--output-encoding", metavar='ENCODING', action="store", dest='encoding', help='Specify encoding to use for --output')
     args = parser.parse_args()
 
     main(args)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Options:
         --includesends          Include Sends in the output.
         --output OUTPUTFILE     Write decrypted output to file.
                                 Will overwrite contents if file exists.
+        --output-encoding ENCODING
+                                Specify encoding to use for --output.
+                                (defaults to the current locale encoding)
 ```
 On Windows:
 ```
@@ -50,6 +53,9 @@ Options:
         --includesends          Include Sends in the output.
         --output OUTPUTFILE     Write decrypted output to file.
                                 Will overwrite contents if file exists.
+        --output-encoding ENCODING
+                                Specify encoding to use for --output
+                                (defaults to 'utf-8')
 ```
 *Note: This script depends on the 'cryptography' package  
 pip install cryptography*


### PR DESCRIPTION
Properly writes JSON output to the file, instead of writing the `__repr__` of a Python `bytes` literal containing the JSON.

Also changes `decryptBitwardenJSON` to return a dictionary instead of JSON-encoded string, and adds `write_json function to handle JSON-encoded output (using `json.dump` instead of `print` or `TextIO.write`).

Fixes #24