### PR TITLE
Support for data.json 2024.1.0 file format

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -53,7 +53,7 @@ import sys
 import uuid
 
 
-# This script depends on the 'cryptography' and 'argon2' package
+# This script depends on the 'cryptography' package
 # pip install cryptography
 try:
     from cryptography.hazmat.backends                   import default_backend
@@ -63,12 +63,21 @@ try:
     from cryptography.hazmat.primitives.ciphers         import Cipher, algorithms, modes
     from cryptography.hazmat.primitives.asymmetric      import rsa, padding as asymmetricpadding
     from cryptography.hazmat.primitives.serialization   import load_der_private_key
-    import argon2
 
 except ModuleNotFoundError:
     print("This script depends on the 'cryptography' package")
     print("pip install cryptography")
     sys.exit(1)
+    
+# This script depends on the 'argon2-cffi' package
+# pip install argon2-cffi
+try:
+    import argon2
+
+except ModuleNotFoundError:
+    print("This script depends on the 'argon2-cffi' package")
+    print("pip install argon2-cffi")
+    sys.exit(1)    
 
 BitwardenSecrets = {}
 

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -404,7 +404,10 @@ def checkFileFormatVersion(options):
         if ('kdfParallelism' in datafile[options.account['UUID']]['profile']):    
             kdfParallelism = datafile[options.account['UUID']]['profile']['kdfParallelism']
         kdfType = datafile[options.account['UUID']]['profile']['kdfType']
-        encKey = datafile[options.account['UUID']]['keys']['cryptoSymmetricKey']['encrypted']
+        if ('masterKeyEncryptedUserKey' in datafile[options.account['UUID']]['keys']):
+            encKey = datafile[options.account['UUID']]['keys']['masterKeyEncryptedUserKey']
+        else:
+            encKey = datafile[options.account['UUID']]['keys']['cryptoSymmetricKey']['encrypted']
         encPrivateKey = datafile[options.account['UUID']]['keys']['privateKey']['encrypted']
 
     else:
@@ -473,15 +476,16 @@ def decryptBitwardenJSON(options):
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']
 
         # Get/Decrypt All Organization Keys
-        for uuid, value in organizationKeys.items():
-            # File Format >= Desktop 2022.8.0
-            if type(value) is dict:
-                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value['key'], BitwardenSecrets['RSAPrivateKey'])
-            # File Format < Desktop 2022.8.0
-            elif type(value) is str:
-                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value, BitwardenSecrets['RSAPrivateKey'])
-            else:
-                print(f"ERROR: Could Not Determine Organization Keys From File Format")
+        if len(datafile['keys']['organizationKeys']['encrypted']) > 0:
+            for uuid, value in organizationKeys.items():
+                # File Format >= Desktop 2022.8.0
+                if type(value) is dict:
+                    BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value['key'], BitwardenSecrets['RSAPrivateKey'])
+                # File Format < Desktop 2022.8.0
+                elif type(value) is str:
+                    BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value, BitwardenSecrets['RSAPrivateKey'])
+                else:
+                    print(f"ERROR: Could Not Determine Organization Keys From File Format")
 
 
         for a in datafile['data']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cryptography>=3.3.2
+argon2-cffi>=18.2.0


### PR DESCRIPTION
Added support for changes in structure for data.json introduced in recent versions of Bitwarden desktop and CLI clients.
Supported are data.json files up to version 2024.1.0.
Additional changes were introduced in versions from 2024.2.0 onwards, these are not supported by this branch.