### PR TITLE
Support for Cipher keys and data.json 2024.7.1 file format

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -53,7 +53,7 @@ import sys
 import uuid
 
 
-# This script depends on the 'cryptography' and 'argon2' package
+# This script depends on the 'cryptography' package
 # pip install cryptography
 try:
     from cryptography.hazmat.backends                   import default_backend
@@ -63,12 +63,21 @@ try:
     from cryptography.hazmat.primitives.ciphers         import Cipher, algorithms, modes
     from cryptography.hazmat.primitives.asymmetric      import rsa, padding as asymmetricpadding
     from cryptography.hazmat.primitives.serialization   import load_der_private_key
-    import argon2
 
 except ModuleNotFoundError:
     print("This script depends on the 'cryptography' package")
     print("pip install cryptography")
     sys.exit(1)
+    
+# This script depends on the 'argon2-cffi' package
+# pip install argon2-cffi
+try:
+    import argon2
+
+except ModuleNotFoundError:
+    print("This script depends on the 'argon2-cffi' package")
+    print("pip install argon2-cffi")
+    sys.exit(1)    
 
 BitwardenSecrets = {}
 

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -404,7 +404,10 @@ def checkFileFormatVersion(options):
         if ('kdfParallelism' in datafile[options.account['UUID']]['profile']):    
             kdfParallelism = datafile[options.account['UUID']]['profile']['kdfParallelism']
         kdfType = datafile[options.account['UUID']]['profile']['kdfType']
-        encKey = datafile[options.account['UUID']]['keys']['cryptoSymmetricKey']['encrypted']
+        if ('masterKeyEncryptedUserKey' in datafile[options.account['UUID']]['keys']):
+            encKey = datafile[options.account['UUID']]['keys']['masterKeyEncryptedUserKey']
+        else:
+            encKey = datafile[options.account['UUID']]['keys']['cryptoSymmetricKey']['encrypted']
         encPrivateKey = datafile[options.account['UUID']]['keys']['privateKey']['encrypted']
 
     else:
@@ -473,15 +476,16 @@ def decryptBitwardenJSON(options):
         organizationKeys = datafile['keys']['organizationKeys']['encrypted']
 
         # Get/Decrypt All Organization Keys
-        for uuid, value in organizationKeys.items():
-            # File Format >= Desktop 2022.8.0
-            if type(value) is dict:
-                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value['key'], BitwardenSecrets['RSAPrivateKey'])
-            # File Format < Desktop 2022.8.0
-            elif type(value) is str:
-                BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value, BitwardenSecrets['RSAPrivateKey'])
-            else:
-                print(f"ERROR: Could Not Determine Organization Keys From File Format")
+        if len(datafile['keys']['organizationKeys']['encrypted']) > 0:
+            for uuid, value in organizationKeys.items():
+                # File Format >= Desktop 2022.8.0
+                if type(value) is dict:
+                    BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value['key'], BitwardenSecrets['RSAPrivateKey'])
+                # File Format < Desktop 2022.8.0
+                elif type(value) is str:
+                    BitwardenSecrets['OrgSecrets'][uuid] = decryptRSA(value, BitwardenSecrets['RSAPrivateKey'])
+                else:
+                    print(f"ERROR: Could Not Determine Organization Keys From File Format")
 
 
         for a in datafile['data']:

--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -528,11 +528,21 @@ def decryptBitwardenJSON(options):
                                     else:
                                         encKey = BitwardenSecrets['OrgSecrets'][groupItem['organizationId']][0:32]
                                         macKey = BitwardenSecrets['OrgSecrets'][groupItem['organizationId']][32:64]
+                                    
+                                    # Cipher Key decryption    
+                                    if groupItem.get('key', None) is None:
+                                        cipherEncKey = encKey
+                                        cipherMacKey = macKey
+                                    else:
+                                        cipherKey, \
+                                        cipherEncKey, \
+                                        cipherMacKey = decryptProtectedSymmetricKey(groupItem.get('key'), encKey, macKey) 
 
-                                    for match in regexPattern.findall(tempString):    
-                                        jsonEscapedString = json.JSONEncoder().encode(decryptCipherString(match, encKey, macKey))
+                                    for match in regexPattern.findall(tempString):
+                                        jsonEscapedString = json.JSONEncoder().encode(decryptCipherString(match, cipherEncKey, cipherMacKey))
                                         jsonEscapedString = jsonEscapedString[1:(len(jsonEscapedString)-1)]
                                         tempString = tempString.replace(match, jsonEscapedString)
+                                        tempString = tempString.replace('"key": "ERROR: MAC did not match. CipherString not decrypted."', '"key": ""')
 
                                 except Exception as e:
                                     print(f"ERROR: Could Not Determine encKey/macKey for: {groupItem.get('id')}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cryptography>=3.3.2
+argon2-cffi>=18.2.0


### PR DESCRIPTION
Added support for both Cipher keys as well as for the new data.json file format. It shall address all the changes they have introduced during year 2024. I have tested it using current CLI 2024.7.1 on both Bitwarden as well as Vaultwarden.

This branch includes also all changes in pull request https://github.com/GurpreetKang/BitwardenDecrypt/pull/23 and https://github.com/GurpreetKang/BitwardenDecrypt/pull/30, which has not been merged yet.


