### PR TITLE
Fix KDF parameters for encrypted JSON

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -355,8 +355,10 @@ def checkFileFormatVersion(options):
 
         # Email address is used as the salt in data.json, in password protected excrypted json exports there is an explicit salt key/value (and no email).
         email = datafile.get("salt")
+        kdfType = int(datafile.get("kdfType"))
         kdfIterations = int(datafile.get("kdfIterations"))
-        kdfType = 0         
+        kdfMemory = int(datafile.get("kdfMemory"))
+        kdfParallelism = int(datafile.get("kdfParallelism"))
         encKey = datafile.get("encKeyValidation_DO_NOT_EDIT")
 
     # Check if data.json is 2024/new/old format.


### PR DESCRIPTION
I was trying to decrypt a current encrypted JSON export (file format `EncryptedJSON`) and always got ‘MAC did not match’ errors. I realised that for this file format, `kdfType` is currently hard coded to 0, but my file uses `kdfType` 1.

With this change, my file works. `kdfType` is no longer hard-coded and all KDF parameters are read from the file. I have however no way of testing older exports.