### PR TITLE
Add uv inline script metadata for runtime dependency install

### DIFF
--- a/BitwardenDecrypt.py
+++ b/BitwardenDecrypt.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "cryptography",
+#     "argon2-cffi",
+# ]
+# ///
 
 # Copyright © 2020-2022 Gurpreet Kang
 # All rights reserved.


### PR DESCRIPTION
Adds a PEP 723 script header so the file can be run directly with `uv run` (or via the shebang) and uv will install `cryptography` and `argon2-cffi` on demand, removing the need for a manual pip install.